### PR TITLE
allow subdoain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,19 @@ By default 404 and 403 errors are redirected to `/index.html` but this is config
 
 This module is also published to the [Terraform community module registry](https://registry.terraform.io/modules/joshuamkite/static-website-s3-cloudfront-acm/aws/latest)
 
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name                                                                      | Version   |
-| ------------------------------------------------------------------------- | --------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.8  |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 4.29.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.8 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.29.0 |
 
 ## Providers
 
-| Name                                                                            | Version   |
-| ------------------------------------------------------------------------------- | --------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws)                               | >= 4.29.0 |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.29.0 |
 | <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | >= 4.29.0 |
 
 ## Modules
@@ -26,48 +27,50 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                                                      | Type        |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_acm_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate)                                   | resource    |
-| [aws_acm_certificate_validation.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation)             | resource    |
-| [aws_cloudfront_distribution.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution)                   | resource    |
-| [aws_cloudfront_origin_access_control.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource    |
-| [aws_route53_record.domain_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record)                              | resource    |
-| [aws_route53_record.validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record)                               | resource    |
-| [aws_route53_record.www_domain_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record)                          | resource    |
-| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket)                                               | resource    |
-| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy)                                 | resource    |
-| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block)       | resource    |
-| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning)                         | resource    |
-| [aws_s3_object.sample_image](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object)                                       | resource    |
-| [aws_s3_object.sample_index_html](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object)                                  | resource    |
-| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                        | data source |
-| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone)                                      | data source |
+| Name | Type |
+|------|------|
+| [aws_acm_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
+| [aws_acm_certificate_validation.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
+| [aws_cloudfront_distribution.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
+| [aws_cloudfront_origin_access_control.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
+| [aws_route53_record.domain_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.validation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.www_domain_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_object.sample_image](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
+| [aws_s3_object.sample_index_html](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
-| Name                                                                                                                                              | Description                                                                                                | Type                                                                                                                                                                                      | Default                                                                                                                                                                                                                                                                                                                    | Required |
-| ------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------: |
-| <a name="input_cloudfront_custom_error_responses"></a> [cloudfront\_custom\_error\_responses](#input\_cloudfront\_custom\_error\_responses)       | See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/GeneratingCustomErrorResponses.html | <pre>list(object({<br>    error_code            = number<br>    response_code         = number<br>    error_caching_min_ttl = number<br>    response_page_path    = string<br>  }))</pre> | <pre>[<br>  {<br>    "error_caching_min_ttl": 10,<br>    "error_code": 403,<br>    "response_code": 404,<br>    "response_page_path": "/index.html"<br>  },<br>  {<br>    "error_caching_min_ttl": 10,<br>    "error_code": 404,<br>    "response_code": 404,<br>    "response_page_path": "/index.html"<br>  }<br>]</pre> |    no    |
-| <a name="input_cloudfront_default_root_object"></a> [cloudfront\_default\_root\_object](#input\_cloudfront\_default\_root\_object)                | Default root object for cloudfront. Need to also provide custom error response if changing from default    | `string`                                                                                                                                                                                  | `"index.html"`                                                                                                                                                                                                                                                                                                             |    no    |
-| <a name="input_cloudfront_default_ttl"></a> [cloudfront\_default\_ttl](#input\_cloudfront\_default\_ttl)                                          | The default TTL for the cloudfront cache                                                                   | `number`                                                                                                                                                                                  | `86400`                                                                                                                                                                                                                                                                                                                    |    no    |
-| <a name="input_cloudfront_max_ttl"></a> [cloudfront\_max\_ttl](#input\_cloudfront\_max\_ttl)                                                      | The maximum TTL for the cloudfront cache                                                                   | `number`                                                                                                                                                                                  | `31536000`                                                                                                                                                                                                                                                                                                                 |    no    |
-| <a name="input_cloudfront_min_ttl"></a> [cloudfront\_min\_ttl](#input\_cloudfront\_min\_ttl)                                                      | The minimum TTL for the cloudfront cache                                                                   | `number`                                                                                                                                                                                  | `0`                                                                                                                                                                                                                                                                                                                        |    no    |
-| <a name="input_cloudfront_minimum_protocol_version"></a> [cloudfront\_minimum\_protocol\_version](#input\_cloudfront\_minimum\_protocol\_version) | The minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections.             | `string`                                                                                                                                                                                  | `"TLSv1.2_2019"`                                                                                                                                                                                                                                                                                                           |    no    |
-| <a name="input_cloudfront_price_class"></a> [cloudfront\_price\_class](#input\_cloudfront\_price\_class)                                          | CloudFront distribution price class                                                                        | `string`                                                                                                                                                                                  | `"PriceClass_100"`                                                                                                                                                                                                                                                                                                         |    no    |
-| <a name="input_deploy_sample_content"></a> [deploy\_sample\_content](#input\_deploy\_sample\_content)                                             | Deploy sample content to show website working?                                                             | `bool`                                                                                                                                                                                    | `false`                                                                                                                                                                                                                                                                                                                    |    no    |
-| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name)                                                                             | Domain name for website, used for all resources                                                            | `string`                                                                                                                                                                                  | n/a                                                                                                                                                                                                                                                                                                                        |   yes    |
-| <a name="input_s3_bucket_custom_name"></a> [s3\_bucket\_custom\_name](#input\_s3\_bucket\_custom\_name)                                           | Any non-empty string here will replace default name of bucket `var.domain_name`                            | `string`                                                                                                                                                                                  | `""`                                                                                                                                                                                                                                                                                                                       |    no    |
-| <a name="input_s3_bucket_public_access_block"></a> [s3\_bucket\_public\_access\_block](#input\_s3\_bucket\_public\_access\_block)                 | Apply public access block to S3 bucket?                                                                    | `bool`                                                                                                                                                                                    | `true`                                                                                                                                                                                                                                                                                                                     |    no    |
-| <a name="input_s3_bucket_versioning"></a> [s3\_bucket\_versioning](#input\_s3\_bucket\_versioning)                                                | Apply versioning to S3 bucket?                                                                             | `bool`                                                                                                                                                                                    | `false`                                                                                                                                                                                                                                                                                                                    |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloudfront_custom_error_responses"></a> [cloudfront\_custom\_error\_responses](#input\_cloudfront\_custom\_error\_responses) | See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/GeneratingCustomErrorResponses.html | <pre>list(object({<br/>    error_code            = number<br/>    response_code         = number<br/>    error_caching_min_ttl = number<br/>    response_page_path    = string<br/>  }))</pre> | <pre>[<br/>  {<br/>    "error_caching_min_ttl": 10,<br/>    "error_code": 403,<br/>    "response_code": 404,<br/>    "response_page_path": "/index.html"<br/>  },<br/>  {<br/>    "error_caching_min_ttl": 10,<br/>    "error_code": 404,<br/>    "response_code": 404,<br/>    "response_page_path": "/index.html"<br/>  }<br/>]</pre> | no |
+| <a name="input_cloudfront_default_root_object"></a> [cloudfront\_default\_root\_object](#input\_cloudfront\_default\_root\_object) | Default root object for cloudfront. Need to also provide custom error response if changing from default | `string` | `"index.html"` | no |
+| <a name="input_cloudfront_default_ttl"></a> [cloudfront\_default\_ttl](#input\_cloudfront\_default\_ttl) | The default TTL for the cloudfront cache | `number` | `86400` | no |
+| <a name="input_cloudfront_max_ttl"></a> [cloudfront\_max\_ttl](#input\_cloudfront\_max\_ttl) | The maximum TTL for the cloudfront cache | `number` | `31536000` | no |
+| <a name="input_cloudfront_min_ttl"></a> [cloudfront\_min\_ttl](#input\_cloudfront\_min\_ttl) | The minimum TTL for the cloudfront cache | `number` | `0` | no |
+| <a name="input_cloudfront_minimum_protocol_version"></a> [cloudfront\_minimum\_protocol\_version](#input\_cloudfront\_minimum\_protocol\_version) | The minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections. | `string` | `"TLSv1.2_2019"` | no |
+| <a name="input_cloudfront_price_class"></a> [cloudfront\_price\_class](#input\_cloudfront\_price\_class) | CloudFront distribution price class | `string` | `"PriceClass_100"` | no |
+| <a name="input_deploy_sample_content"></a> [deploy\_sample\_content](#input\_deploy\_sample\_content) | Deploy sample content to show website working? | `bool` | `false` | no |
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name for website, used for all resources | `string` | n/a | yes |
+| <a name="input_parent_zone_name"></a> [parent\_zone\_name](#input\_parent\_zone\_name) | Parent hosted zone name (for subdomains). If not set, uses domain\_name | `string` | `""` | no |
+| <a name="input_s3_bucket_custom_name"></a> [s3\_bucket\_custom\_name](#input\_s3\_bucket\_custom\_name) | Any non-empty string here will replace default name of bucket `var.domain_name` | `string` | `""` | no |
+| <a name="input_s3_bucket_public_access_block"></a> [s3\_bucket\_public\_access\_block](#input\_s3\_bucket\_public\_access\_block) | Apply public access block to S3 bucket? | `bool` | `true` | no |
+| <a name="input_s3_bucket_versioning"></a> [s3\_bucket\_versioning](#input\_s3\_bucket\_versioning) | Apply versioning to S3 bucket? | `bool` | `false` | no |
 
 ## Outputs
 
-| Name                                                                                                                   | Description                                         |
-| ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| <a name="output_acm_certificate_id"></a> [acm\_certificate\_id](#output\_acm\_certificate\_id)                         | n/a                                                 |
-| <a name="output_cloudfront_distribution_id"></a> [cloudfront\_distribution\_id](#output\_cloudfront\_distribution\_id) | n/a                                                 |
-| <a name="output_cloudfront_domain_name"></a> [cloudfront\_domain\_name](#output\_cloudfront\_domain\_name)             | n/a                                                 |
-| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn)                                        | n/a                                                 |
-| <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id)                                           | n/a                                                 |
-| <a name="output_s3_bucket_name"></a> [s3\_bucket\_name](#output\_s3\_bucket\_name)                                     | deprecated and will be removed - use `s3_bucket_id` |
+| Name | Description |
+|------|-------------|
+| <a name="output_acm_certificate_id"></a> [acm\_certificate\_id](#output\_acm\_certificate\_id) | n/a |
+| <a name="output_cloudfront_distribution_id"></a> [cloudfront\_distribution\_id](#output\_cloudfront\_distribution\_id) | n/a |
+| <a name="output_cloudfront_domain_name"></a> [cloudfront\_domain\_name](#output\_cloudfront\_domain\_name) | n/a |
+| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | n/a |
+| <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | n/a |
+| <a name="output_s3_bucket_name"></a> [s3\_bucket\_name](#output\_s3\_bucket\_name) | deprecated and will be removed - use `s3_bucket_id` |
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
Permit optionally giving parent domain and subdomain (historic default behaviour preserved)


## Backward Compatibility

**[`variables.tf`](/Users/joshua/code-joshua/terraform-aws-static-website-s3-cloudfront-acm/variables.tf:6-10)**:
```hcl
variable "parent_zone_name" {
  type        = string
  description = "Parent hosted zone name (for subdomains). If not set, uses domain_name"
  default     = ""
}
```

**[`dns.tf`](/Users/joshua/code-joshua/terraform-aws-static-website-s3-cloudfront-acm/dns.tf:14)**:
```hcl
data "aws_route53_zone" "this" {
  name         = var.parent_zone_name != "" ? var.parent_zone_name : var.domain_name
  private_zone = false
}
```

## How It Works

- **Default behavior** (when `parent_zone_name` is not provided): Uses `var.domain_name` for hosted zone lookup - exactly as before
- **New subdomain feature** (when `parent_zone_name` is provided): Uses `var.parent_zone_name` instead

## Examples

**Original usage (unchanged)**:
```hcl
module "website" {
  source      = "joshuamkite/static-website-s3-cloudfront-acm/aws"
  domain_name = "example.com"
}
# Looks up hosted zone: example.com
```

**New subdomain usage**:
```hcl
module "website" {
  source           = "joshuamkite/static-website-s3-cloudfront-acm/aws"
  domain_name      = "app.example.com"
  parent_zone_name = "example.com"
}
# Looks up hosted zone: example.com (parent)
```

The change is fully backward compatible - existing configurations will continue to work without modification.

